### PR TITLE
Update RailroaderRD.cs to Ignore RailDriver when locomotive is in AI mode

### DIFF
--- a/src/RailroaderRD.cs
+++ b/src/RailroaderRD.cs
@@ -1,4 +1,4 @@
-﻿using Character;
+using Character;
 using Model;
 using Railloader;
 using Serilog;
@@ -15,6 +15,7 @@ using Effects;
 using KeyValue.Runtime;
 using UnityEngine.InputSystem;
 using static UnityEngine.InputSystem.InputActionRebindingExtensions;
+using Model.AI;
 
 namespace RailroaderRD;
 
@@ -25,6 +26,8 @@ public class RailroaderRD : PluginBase, IUpdateHandler, IModTabHandler
     ILogger logger = Log.ForContext<RailroaderRD>();
     RaildriverInterface raildriver = null;
     IModdingContext modContext;
+
+    static AccessTools.FieldRef<AutoEngineerPlanner, Orders> _ordersRef = AccessTools.FieldRefAccess<AutoEngineerPlanner, Orders>("_orders");
 
     public static RailroaderRD Instance { get; set; }
 
@@ -99,38 +102,43 @@ public class RailroaderRD : PluginBase, IUpdateHandler, IModTabHandler
             {
                 raildriver.UpdateVelocityDisplay(Math.Abs(loco.velocity));
 
-                loco.ControlHelper.Reverser = -raildriver.Reverser;
-                loco.ControlHelper.Throttle = raildriver.Throttle;
-                loco.ControlHelper.TrainBrake = 1.0f - raildriver.AutoBrake;
-                loco.ControlHelper.LocomotiveBrake = 1.0f - raildriver.IndBrake;
-                
-                if (raildriver.BailOff > 0.7f)
-                    loco.ControlHelper.BailOff();
+                Orders orders = _ordersRef(controller.SelectedLocomotive.AutoEngineerPlanner);
 
-                int headlight = (int)Math.Round(raildriver.Lights * 2.0f);
-                int bits = HeadlightStateLogic.IntFromStates((HeadlightController.State)headlight, (HeadlightController.State)headlight);
-                if (bits != GetValue(loco, PropertyChange.Control.Headlight).IntValue)
+                if (orders.Enabled == false)
                 {
-                    ChangeValue(loco, PropertyChange.Control.Headlight, bits);
+                    loco.ControlHelper.Reverser = -raildriver.Reverser;
+                    loco.ControlHelper.Throttle = raildriver.Throttle;
+                    loco.ControlHelper.TrainBrake = 1.0f - raildriver.AutoBrake;
+                    loco.ControlHelper.LocomotiveBrake = 1.0f - raildriver.IndBrake;
+
+                    if (raildriver.BailOff > 0.7f)
+                        loco.ControlHelper.BailOff();
+
+                    int headlight = (int)Math.Round(raildriver.Lights * 2.0f);
+                    int bits = HeadlightStateLogic.IntFromStates((HeadlightController.State)headlight, (HeadlightController.State)headlight);
+                    if (bits != GetValue(loco, PropertyChange.Control.Headlight).IntValue)
+                    {
+                        ChangeValue(loco, PropertyChange.Control.Headlight, bits);
+                    }
+
+                    ButtonMask downMask = raildriver.Buttons;
+                    ButtonMask pressed = downMask & (downMask ^ prevMask);
+
+                    if (pressed.HasFlag(ButtonMask.Bell))
+                    {
+                        loco.ControlHelper.Bell = !loco.ControlHelper.Bell;
+                    }
+
+                    float whistle = 0.0f;
+                    if (downMask.HasFlag(ButtonMask.WhistleUp))
+                        whistle += 1.0f;
+                    if (downMask.HasFlag(ButtonMask.WhistleDown))
+                        whistle += 0.5f;
+
+                    loco.ControlHelper.Horn = whistle;
+
+                    prevMask = downMask;
                 }
-
-                ButtonMask downMask = raildriver.Buttons;
-                ButtonMask pressed = downMask & (downMask ^ prevMask);
-
-                if (pressed.HasFlag(ButtonMask.Bell))
-                {
-                    loco.ControlHelper.Bell = !loco.ControlHelper.Bell;
-                }
-
-                float whistle = 0.0f;
-                if (downMask.HasFlag(ButtonMask.WhistleUp))
-                    whistle += 1.0f;
-                if (downMask.HasFlag(ButtonMask.WhistleDown))
-                    whistle += 0.5f;
-
-                loco.ControlHelper.Horn = whistle;
-
-                prevMask = downMask;
             }
             else
             {

--- a/src/RailroaderRD.cs
+++ b/src/RailroaderRD.cs
@@ -102,9 +102,18 @@ public class RailroaderRD : PluginBase, IUpdateHandler, IModTabHandler
             {
                 raildriver.UpdateVelocityDisplay(Math.Abs(loco.velocity));
 
-                Orders orders = _ordersRef(controller.SelectedLocomotive.AutoEngineerPlanner);
+                bool ignore_input = false;
 
-                if (orders.Enabled == false)
+                if (controller.SelectedLocomotive.AutoEngineerPlanner != null)
+                {
+                    Orders orders = _ordersRef(controller.SelectedLocomotive.AutoEngineerPlanner);
+                    if (orders.Enabled == true)
+                    {
+                        ignore_input = true;
+                    }
+                }
+
+                if (!ignore_input)
                 {
                     loco.ControlHelper.Reverser = -raildriver.Reverser;
                     loco.ControlHelper.Throttle = raildriver.Throttle;
@@ -302,4 +311,3 @@ public class RailroaderRD : PluginBase, IUpdateHandler, IModTabHandler
         //  SaveConfig();
     }
 }
-


### PR DESCRIPTION
Before this fix if you put your selected locomotive in AI mode (road or yard) the update method will continuously override the locomotive and the locomotive will not move per the AI's instructions. 

This commit makes the update method check for AI modes, and if in an AI mode, do not check the rail drivers current state.

The code change was 

1. Added Model.AI import
2. Add a new static AccessTool to get the AutoEngineerPlanner's private _orders field. 
3. In the Update() method use the new AccessTool to get the _orders field
4. Wrap the main content of the update() method around if orders.enabled == false, meaning if in manual mode ....